### PR TITLE
Fix broken links by removing nav's onClickOutside

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10667,11 +10667,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-onclickoutside": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz",
-      "integrity": "sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A=="
-    },
     "react-router": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/user-event": "^7.2.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-onclickoutside": "^6.9.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1"
   },

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import onClickOutside from "react-onclickoutside";
 import { Link } from 'react-router-dom';
 
 import { PageCtx } from '../../utils/PageCtx'
@@ -116,8 +115,4 @@ function Nav(props) {
         </nav >)
 }
 
-const clickOutsideConfig = {
-    handleClickOutside: () => Nav.closeDdNav
-};
-
-export default onClickOutside(Nav, clickOutsideConfig);
+export default Nav


### PR DESCRIPTION
The onClickOutside functionality for the navbar caused anchors in
the DOM not to open their links. The need for these links to work is
high and my time to investigate is low, so this feature has been cut.

Navbar will now have to be closed manually if a user does not
navigate to a new page.